### PR TITLE
the assistants configs also need to be copied just like plugins

### DIFF
--- a/dotnet/samples/06-Assistants/06-Assistants.csproj
+++ b/dotnet/samples/06-Assistants/06-Assistants.csproj
@@ -31,5 +31,8 @@
     <Content Include="Plugins\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assistants\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
needed for debugging, otherwise application throws error trying to load files in ./Assistants